### PR TITLE
Build improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ ionc/libionc.a
 test/tester
 tools/ionizer/ionizer
 tools/ionsymbols/ionsymbols
-
+build

--- a/build-debug
+++ b/build-debug
@@ -1,6 +1,6 @@
 #!/bin/sh --
 
-mkdir build/debug
+mkdir -p build/debug
 cd build/debug
 cmake -DCMAKE_BUILD_TYPE=Debug ../..
 make clean && make

--- a/build-release
+++ b/build-release
@@ -1,6 +1,6 @@
 #!/bin/sh --
 
-mkdir build/release
+mkdir -p build/release
 cd build/release
 cmake -DCMAKE_BUILD_TYPE=Release ../..
 make clean && make

--- a/tools/ionizer/options.c
+++ b/tools/ionizer/options.c
@@ -10,8 +10,8 @@
 #include <stdio.h>
 #ifdef WIN
 #include <io.h>
-#endif
 #include <malloc.h>
+#endif
 #include <string.h>
 #include <ctype.h>
 

--- a/tools/ionsymbols/options.c
+++ b/tools/ionsymbols/options.c
@@ -10,8 +10,8 @@
 #include <stdio.h>
 #ifdef WIN
 #include <io.h>
-#endif
 #include <malloc.h>
+#endif
 #include <string.h>
 #include <ctype.h>
 


### PR DESCRIPTION
Creates the intermediate `build` directory before changing into it.

Conditionally includes `malloc.h` on Windows (`malloc(3)` is  part of `stdlib.h` in C99).

Tested on:

* OS X 10.11.5
* FreeBSD 10.3
* CentOS 7.2